### PR TITLE
Keep status bar greeting persistant during theme change

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -4026,6 +4026,7 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
     void updateResources() {
         final Context context = mContext;
         final Resources res = context.getResources();
+        ContentResolver resolver = mContext.getContentResolver();
 
         // detect theme change.
         ThemeConfig newTheme = res.getConfiguration().themeConfig;
@@ -4033,6 +4034,14 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
                 (mCurrentTheme == null || !mCurrentTheme.equals(newTheme))) {
             mCurrentTheme = (ThemeConfig)newTheme.clone();
             recreateStatusBar();
+            
+        // detect greeting state when theme change.
+		mGreeting = Settings.System.getStringForUser(
+				resolver, Settings.System.STATUS_BAR_GREETING,
+					UserHandle.USER_CURRENT);
+			if (mGreeting != null && !TextUtils.isEmpty(mGreeting)) {
+					mExodusLabel.setText(mGreeting);
+			}
         } else {
             loadDimens();
         }


### PR DESCRIPTION
This fixes the status bar greeting resetting to the default text on theme change
